### PR TITLE
Update build.txt

### DIFF
--- a/build.txt
+++ b/build.txt
@@ -1,6 +1,6 @@
 {
-    name = "assimp",
+    name = "open3d",
     versions = {
-        "v5.2.3"
+        "v0.15.1"
     }
 }


### PR DESCRIPTION
ci上的build_artifacts.lua用了packages.is_supported(instance, "windows")作为判据，但是open3d仅支持windows|x64，所以没扫到；这里改一下比较好，对x86或者x64 windows支持就可以传到build-artifacts上