### PR TITLE
Build glib 2.88.1

### DIFF
--- a/build.txt
+++ b/build.txt
@@ -1,6 +1,6 @@
 {
-    name = "cairo",
+    name = "glib",
     versions = {
-        "1.18.4"
+        "2.88.1"
     }
 }


### PR DESCRIPTION
Precompiled version didn't have the .pc file patch relating to libintl, hence the rebuild.